### PR TITLE
Fix project state management for document operations

### DIFF
--- a/src/features/project/project_operation.py
+++ b/src/features/project/project_operation.py
@@ -28,6 +28,7 @@ class ProjectOperation:
             - switch: Switch to different project
             - list: List all projects
             - info: Get current project info
+            - close: Close current project and return to Documents mode
             - archive: Archive a project (future)
         """
         action_map = {
@@ -35,6 +36,7 @@ class ProjectOperation:
             "switch": self._switch_project,
             "list": self._list_projects,
             "info": self._project_info,
+            "close": self._close_project,
             "archive": self._archive_project
         }
         
@@ -70,6 +72,11 @@ class ProjectOperation:
                     "description": "Get information about current project",
                     "required_params": [],
                     "optional_params": ["detailed"]
+                },
+                "close": {
+                    "description": "Close current project and return to Documents mode",
+                    "required_params": [],
+                    "optional_params": []
                 },
                 "archive": {
                     "description": "Archive a project",
@@ -222,6 +229,36 @@ class ProjectOperation:
                 }
             
             return response
+            
+        except Exception as e:
+            return {"error": str(e)}
+    
+    def _close_project(self, params: Dict[str, Any], context: Dict[str, Any]) -> Dict[str, Any]:
+        """Close the current project."""
+        try:
+            result = self.texflow.close_project()
+            
+            # Check if no project was active
+            if "no project is currently active" in result.lower():
+                return {
+                    "success": True,
+                    "action": "close",
+                    "message": "No project was active",
+                    "hint": "File operations already use ~/Documents/ by default"
+                }
+            
+            # Extract closed project name from result
+            import re
+            name_match = re.search(r"Closed project '(.+?)'", result)
+            project_name = name_match.group(1) if name_match else "Unknown"
+            
+            return {
+                "success": True,
+                "action": "close",
+                "closed_project": project_name,
+                "message": f"Project '{project_name}' closed successfully",
+                "hint": "File operations will now use ~/Documents/ by default"
+            }
             
         except Exception as e:
             return {"error": str(e)}


### PR DESCRIPTION
## Summary
- Fixed critical bug where document operations weren't respecting the active project directory
- Added `close_project()` tool to allow returning to default Documents mode
- Improved path resolution consistency across all document tools

## Problem
When a project was active (e.g., after `create_project("demo-document")`), file operations like `markdown_to_latex` were incorrectly looking in `~/Documents/` instead of the project directory (`~/Documents/TeXFlow/demo-document/`). This made the project management feature unusable.

## Solution
1. **Updated path resolution** in critical functions to use the centralized `resolve_project_path()` function:
   - `markdown_to_latex` - now respects project context for both input and output paths
   - `read_document` - uses project-aware path resolution
   - `edit_document` - uses project-aware path resolution  
   - `check_document_status` - uses project-aware path resolution

2. **Added `close_project()` tool** that:
   - Clears the current project state
   - Updates the config file
   - Returns file operations to default `~/Documents/` behavior

3. **Updated semantic wrapper** to include the new close action in `ProjectOperation`

## Test plan
- [x] Create a project with `create_project("test-project")`
- [x] Save a markdown file with `save_markdown()` - should go to project directory
- [x] Convert markdown to LaTeX with `markdown_to_latex()` - should find file in project
- [x] Read/edit documents - should work within project context
- [x] Close project with `close_project()` - should return to Documents mode
- [x] Save files after closing - should go to `~/Documents/`

🤖 Generated with [Claude Code](https://claude.ai/code)