### PR TITLE
feat: Add font discovery to discover tool

### DIFF
--- a/docs/UNIFIED_TOOL_REFERENCE.md
+++ b/docs/UNIFIED_TOOL_REFERENCE.md
@@ -151,13 +151,19 @@ Finds documents, fonts, and system capabilities.
 
 **Examples:**
 ```python
+discover(action="fonts")
+# → Lists all available font families (e.g., Barlow, DejaVu Serif)
+# → Shows: "📝 Available fonts (296 found)..."
+
 discover(action="fonts", style="serif")
-# → Lists serif fonts for LaTeX
-# → Suggests: create document with custom font
+# → Filters to serif fonts only
+# → Also supports: sans, mono, display
 
 discover(action="capabilities")
-# → Shows what's installed (pandoc, XeLaTeX, etc.)
+# → Shows what's installed (pandoc, XeLaTeX, fontconfig, etc.)
 ```
+
+**Font Usage Note**: After discovering fonts, use them in LaTeX with `\setmainfont{FontName}`. If a desired font isn't available, install it at the system level first.
 
 ### 6. `archive` - Version Management
 


### PR DESCRIPTION
## Summary

This PR adds font discovery capabilities to the discover tool, allowing users to browse available system fonts for use in LaTeX documents.

## Features Added

### Font Discovery Action
- New `fonts` action in the discover tool
- Lists all available font families using `fc-list` command
- Deduplicates font variants to show clean family names
- Limits output to 50 fonts to avoid overwhelming users

### Style Filtering
- Support for filtering fonts by style:
  - `serif` - Serif fonts (Times, Georgia, etc.)
  - `sans` - Sans-serif fonts (Arial, Helvetica, etc.)
  - `mono` - Monospace fonts (Courier, Consolas, etc.)
  - `display` - Display/decorative fonts

### System Integration
- Uses standard `fc-list` command from fontconfig package
- Added fontconfig check to capabilities action
- Graceful error handling if fontconfig not installed

## Example Usage

```python
# List all fonts
discover(action="fonts")
# → 📝 Available fonts (296 found)...

# Find serif fonts for formal documents
discover(action="fonts", style="serif")
# → 📝 Available serif fonts (45 found)...

# Find monospace fonts for code
discover(action="fonts", style="mono")
# → 📝 Available mono fonts (25 found)...
```

## Benefits

1. **No more external bash commands** - Font discovery is now part of the semantic tool interface
2. **Filtered results** - Users can find appropriate fonts by style
3. **LaTeX hints** - Output includes usage hints for `\setmainfont{}`
4. **Clean output** - Deduplication prevents variant clutter

## Testing

Tested with local font discovery:
- [x] Lists all system fonts correctly
- [x] Style filtering works for all categories
- [x] Handles missing fontconfig gracefully
- [x] Output is limited to prevent overflow