### PR TITLE
feat: Add bibliography and citation support with biblatex

### DIFF
--- a/server.py
+++ b/server.py
@@ -65,6 +65,10 @@ def document(
     - read: Read content of a specific section as prose text.
     - update: Update document metadata (title, author, date, abstract).
     - reset: Clear the current document and saved state. Next create/ingest starts fresh.
+    - bib_add: Add a bibliography entry (provide BibTeX-format entry as source).
+    - bib_remove: Remove a bibliography entry by key (provide key as source).
+    - bib_list: List all bibliography entries.
+    - bib_style: Set bibliography style (provide style name as source, e.g. "authoryear", "numeric").
     """
     return _with_hints(document_tool(
         action, document_class, title, author, date, abstract, source, section,

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -1,6 +1,8 @@
 """Tests for the LaTeX serializer."""
 
 from texflow.model import (
+    BibEntry,
+    Bibliography,
     CodeBlock,
     Document,
     DocumentClass,
@@ -17,7 +19,7 @@ from texflow.model import (
     Section,
     Table,
 )
-from texflow.serializer import escape_latex, serialize, _convert_inline_markup
+from texflow.serializer import escape_latex, serialize, serialize_bib, _convert_inline_markup
 
 
 # --- escape_latex ---
@@ -406,3 +408,93 @@ def test_serialize_complete_document():
     assert "\\begin{equation}" in tex
     assert "\\begin{table}" in tex
     assert "\\begin{figure}" in tex
+
+
+# --- Bibliography tests ---
+
+
+class TestCitationInlineMarkup:
+    def test_cite_simple(self):
+        result = _convert_inline_markup("See [@smith2024].")
+        assert result == "See \\cite{smith2024}."
+
+    def test_cite_with_note(self):
+        result = _convert_inline_markup("See [@smith2024, p. 42].")
+        assert result == "See \\cite[p. 42]{smith2024}."
+
+    def test_cite_protected_in_escape(self):
+        text = escape_latex("Citations like [@key] are safe.")
+        assert "[@key]" in text  # Not escaped
+
+    def test_multiple_citations(self):
+        result = _convert_inline_markup("See [@a] and [@b].")
+        assert "\\cite{a}" in result
+        assert "\\cite{b}" in result
+
+
+class TestSerializeBib:
+    def test_empty_bib(self):
+        doc = Document()
+        assert serialize_bib(doc) == ""
+
+    def test_single_entry(self):
+        doc = Document(bibliography=Bibliography(entries=[
+            BibEntry(key="smith2024", entry_type="article", fields={
+                "author": "John Smith",
+                "title": "A Great Paper",
+                "year": "2024",
+            }),
+        ]))
+        bib = serialize_bib(doc)
+        assert "@article{smith2024," in bib
+        assert "author = {John Smith}" in bib
+        assert "title = {A Great Paper}" in bib
+        assert "year = {2024}" in bib
+
+    def test_multiple_entries(self):
+        doc = Document(bibliography=Bibliography(entries=[
+            BibEntry(key="a", entry_type="book", fields={"title": "Book A"}),
+            BibEntry(key="b", entry_type="article", fields={"title": "Paper B"}),
+        ]))
+        bib = serialize_bib(doc)
+        assert "@book{a," in bib
+        assert "@article{b," in bib
+
+
+class TestBiblatexPreamble:
+    def test_biblatex_in_preamble(self):
+        doc = Document(
+            bibliography=Bibliography(
+                style="numeric",
+                entries=[BibEntry(key="k", entry_type="article", fields={"title": "T"})],
+            ),
+        )
+        tex = serialize(doc)
+        assert "\\usepackage[style=numeric,backend=biber]{biblatex}" in tex
+        assert "\\addbibresource{references.bib}" in tex
+
+    def test_printbibliography_at_end(self):
+        doc = Document(
+            bibliography=Bibliography(
+                entries=[BibEntry(key="k", entry_type="article", fields={"title": "T"})],
+            ),
+        )
+        tex = serialize(doc)
+        assert "\\printbibliography" in tex
+        assert "\\bibliographystyle" not in tex
+
+    def test_no_biblatex_without_entries(self):
+        doc = Document()
+        tex = serialize(doc)
+        assert "biblatex" not in tex
+        assert "\\printbibliography" not in tex
+
+    def test_citation_in_paragraph(self):
+        doc = Document(
+            content=[Paragraph(text="See [@smith2024].")],
+            bibliography=Bibliography(
+                entries=[BibEntry(key="smith2024", entry_type="article", fields={"title": "T"})],
+            ),
+        )
+        tex = serialize(doc)
+        assert "\\cite{smith2024}" in tex

--- a/tests/test_tex_ingestion.py
+++ b/tests/test_tex_ingestion.py
@@ -535,6 +535,33 @@ class TestBibFileParsing:
         entries = parse_bib_file("")
         assert len(entries) == 0
 
+    def test_nested_braces(self):
+        bib = "@article{rna, title = {The {RNA} Polymerase}, author = {Jane {van der Berg}}}"
+        entries = parse_bib_file(bib)
+        assert len(entries) == 1
+        assert entries[0].fields["title"] == "The {RNA} Polymerase"
+        assert entries[0].fields["author"] == "Jane {van der Berg}"
+
+
+class TestCitationRoundTrip:
+    def test_serialize_then_ingest(self):
+        from texflow.model import BibEntry, Bibliography
+        from texflow.serializer import serialize
+
+        original = Document(
+            metadata=Metadata(title="Cite Test"),
+            content=[Paragraph(text="See [@smith2024, p. 5].")],
+            bibliography=Bibliography(
+                style="numeric",
+                entries=[BibEntry(key="smith2024", entry_type="article", fields={"title": "T"})],
+            ),
+        )
+        tex = serialize(original)
+        restored = ingest_tex(tex)
+        p = restored.content[0]
+        assert isinstance(p, Paragraph)
+        assert "[@smith2024, p. 5]" in p.text
+
 
 class TestBiblatexPreambleIngestion:
     def test_biblatex_style_detected(self):

--- a/tests/test_tex_ingestion.py
+++ b/tests/test_tex_ingestion.py
@@ -471,3 +471,81 @@ class TestRoundTrip:
         assert isinstance(results.content[0], Table)
         assert isinstance(results.content[1], ItemList)
         assert len(results.content[1].items) == 2
+
+
+# --- Citation and bibliography tests ---
+
+from texflow.tex_ingestion import parse_bib_file, _latex_inline_to_markdown
+
+
+class TestCitationReversal:
+    def test_cite_to_bracket(self):
+        result = _latex_inline_to_markdown("See \\cite{smith2024}.")
+        assert result == "See [@smith2024]."
+
+    def test_cite_with_option(self):
+        result = _latex_inline_to_markdown("See \\cite[p. 42]{smith2024}.")
+        assert result == "See [@smith2024, p. 42]."
+
+    def test_textcite_to_bracket(self):
+        result = _latex_inline_to_markdown("\\textcite{jones2023} argues")
+        assert result == "[@jones2023] argues"
+
+    def test_parencite_to_bracket(self):
+        result = _latex_inline_to_markdown("results \\parencite{doe2022}")
+        assert result == "results [@doe2022]"
+
+    def test_multiple_cites(self):
+        result = _latex_inline_to_markdown("\\cite{a} and \\cite{b}")
+        assert "[@a]" in result
+        assert "[@b]" in result
+
+
+class TestBibFileParsing:
+    def test_single_entry(self):
+        bib = """@article{smith2024,
+  author = {John Smith},
+  title = {A Great Paper},
+  year = {2024}
+}"""
+        entries = parse_bib_file(bib)
+        assert len(entries) == 1
+        assert entries[0].key == "smith2024"
+        assert entries[0].entry_type == "article"
+        assert entries[0].fields["author"] == "John Smith"
+        assert entries[0].fields["title"] == "A Great Paper"
+        assert entries[0].fields["year"] == "2024"
+
+    def test_multiple_entries(self):
+        bib = """@book{a,
+  title = {Book A}
+}
+
+@inproceedings{b,
+  title = {Paper B},
+  year = {2023}
+}"""
+        entries = parse_bib_file(bib)
+        assert len(entries) == 2
+        assert entries[0].key == "a"
+        assert entries[1].key == "b"
+        assert entries[1].entry_type == "inproceedings"
+
+    def test_empty_bib(self):
+        entries = parse_bib_file("")
+        assert len(entries) == 0
+
+
+class TestBiblatexPreambleIngestion:
+    def test_biblatex_style_detected(self):
+        tex = "\\documentclass{article}\n\\usepackage[style=numeric,backend=biber]{biblatex}\n\\begin{document}\n\\end{document}"
+        doc = ingest_tex(tex)
+        assert doc.bibliography is not None
+        assert doc.bibliography.style == "numeric"
+
+    def test_printbibliography_skipped(self):
+        tex = "\\begin{document}\nSome text.\n\\printbibliography\n\\end{document}"
+        doc = ingest_tex(tex)
+        # printbibliography should not appear as content
+        assert len(doc.content) == 1
+        assert isinstance(doc.content[0], Paragraph)

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -892,3 +892,56 @@ class TestPreviewFormatting:
         edit_tool("insert", content="Hello.")
         result = render_tool("preview")
         assert "data:image/png;base64," not in result
+
+
+# --- Bibliography tool tests ---
+
+
+class TestBibActions:
+    def setup_method(self):
+        from texflow.tools import state as st
+        st._current_doc = None
+        document_tool("create", title="Bib Test")
+
+    def test_bib_add(self):
+        result = document_tool("bib_add", source='@article{smith2024, author = {John Smith}, title = {A Paper}, year = {2024}}')
+        assert "smith2024" in result
+        assert "1 total entries" in result
+
+    def test_bib_add_duplicate(self):
+        document_tool("bib_add", source='@article{k, title = {T}}')
+        result = document_tool("bib_add", source='@article{k, title = {T2}}')
+        assert "already exists" in result
+
+    def test_bib_remove(self):
+        document_tool("bib_add", source='@article{k, title = {T}}')
+        result = document_tool("bib_remove", source="k")
+        assert "Removed" in result
+        assert "0 entries" in result
+
+    def test_bib_remove_not_found(self):
+        result = document_tool("bib_remove", source="nonexistent")
+        assert "No bibliography entries" in result
+
+    def test_bib_list_empty(self):
+        result = document_tool("bib_list")
+        assert "No bibliography entries" in result
+
+    def test_bib_list_with_entries(self):
+        document_tool("bib_add", source='@article{smith2024, author = {John Smith}, title = {A Paper}, year = {2024}}')
+        result = document_tool("bib_list")
+        assert "smith2024" in result
+        assert "John Smith" in result
+        assert "A Paper" in result
+
+    def test_bib_style(self):
+        result = document_tool("bib_style", source="numeric")
+        assert "numeric" in result
+
+    def test_bib_style_invalid(self):
+        result = document_tool("bib_style", source="nonexistent")
+        assert "Unknown style" in result
+
+    def test_bib_add_no_source(self):
+        result = document_tool("bib_add")
+        assert "Error" in result

--- a/texflow/compiler.py
+++ b/texflow/compiler.py
@@ -32,11 +32,34 @@ class CompileError:
     context: str = ""
 
 
-def compile_tex(tex_content: str, output_dir: Path | None = None, filename: str = "document") -> CompileResult:
+def _run_engine(engine: str, filename: str, work_dir: Path) -> tuple[str, CompileError | None]:
+    """Run a single LaTeX engine pass. Returns (stdout, error_or_none)."""
+    try:
+        proc = subprocess.run(
+            [engine, "-interaction=nonstopmode", "-halt-on-error", f"{filename}.tex"],
+            cwd=work_dir,
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        return proc.stdout, None
+    except subprocess.TimeoutExpired:
+        return "", CompileError(message="Compilation timed out after 60 seconds")
+    except Exception as e:
+        return "", CompileError(message=f"Compilation failed: {e}")
+
+
+def compile_tex(
+    tex_content: str,
+    output_dir: Path | None = None,
+    filename: str = "document",
+    bib_content: str | None = None,
+) -> CompileResult:
     """Compile a .tex string to PDF using xelatex.
 
-    Runs xelatex twice for TOC/references. Falls back to pdflatex if xelatex
-    is not available. Returns CompileResult with paths and any errors.
+    Runs xelatex → (biber) → xelatex → xelatex for cross-references and
+    bibliography. Falls back to pdflatex if xelatex is not available.
+    Returns CompileResult with paths and any errors.
     """
     if not shutil.which("xelatex") and not shutil.which("pdflatex"):
         # No LaTeX engine available — write .tex only
@@ -59,26 +82,39 @@ def compile_tex(tex_content: str, output_dir: Path | None = None, filename: str 
         tex_path = work_dir / f"{filename}.tex"
         tex_path.write_text(tex_content, encoding="utf-8")
 
+        # Write .bib file if provided
+        if bib_content:
+            bib_path = work_dir / "references.bib"
+            bib_path.write_text(bib_content, encoding="utf-8")
+
         errors: list[CompileError] = []
         warnings: list[str] = []
         log_content = ""
 
-        # Run twice for cross-references
-        for pass_num in range(2):
+        # Pass 1: xelatex
+        log_content, err = _run_engine(engine, filename, work_dir)
+        if err:
+            errors.append(err)
+            return CompileResult(success=False, tex_path=tex_path, errors=errors, log=log_content)
+
+        # Pass 2: biber (conditional — only when bib content provided and biber available)
+        if bib_content and shutil.which("biber"):
             try:
-                proc = subprocess.run(
-                    [engine, "-interaction=nonstopmode", "-halt-on-error", f"{filename}.tex"],
+                subprocess.run(
+                    ["biber", filename],
                     cwd=work_dir,
                     capture_output=True,
                     text=True,
                     timeout=60,
                 )
-                log_content = proc.stdout
-            except subprocess.TimeoutExpired:
-                errors.append(CompileError(message="Compilation timed out after 60 seconds"))
-                return CompileResult(success=False, tex_path=tex_path, errors=errors, log=log_content)
-            except Exception as e:
-                errors.append(CompileError(message=f"Compilation failed: {e}"))
+            except (subprocess.TimeoutExpired, Exception) as e:
+                errors.append(CompileError(message=f"Biber failed: {e}"))
+
+        # Pass 3 & 4: xelatex (resolve references and bibliography)
+        for _ in range(2):
+            log_content, err = _run_engine(engine, filename, work_dir)
+            if err:
+                errors.append(err)
                 return CompileResult(success=False, tex_path=tex_path, errors=errors, log=log_content)
 
         # Parse log for errors and warnings
@@ -101,6 +137,10 @@ def compile_tex(tex_content: str, output_dir: Path | None = None, filename: str 
             if pdf_path.exists():
                 final_pdf = output_dir / f"{filename}.pdf"
                 shutil.copy2(pdf_path, final_pdf)
+            # Copy .bib file too
+            bib_src = work_dir / "references.bib"
+            if bib_src.exists():
+                shutil.copy2(bib_src, output_dir / "references.bib")
 
         return CompileResult(
             success=success,

--- a/texflow/compiler.py
+++ b/texflow/compiler.py
@@ -107,7 +107,7 @@ def compile_tex(
                     text=True,
                     timeout=60,
                 )
-            except (subprocess.TimeoutExpired, Exception) as e:
+            except Exception as e:
                 errors.append(CompileError(message=f"Biber failed: {e}"))
 
         # Pass 3 & 4: xelatex (resolve references and bibliography)

--- a/texflow/model.py
+++ b/texflow/model.py
@@ -83,8 +83,14 @@ class BibEntry:
 
 @dataclass
 class Bibliography:
-    style: str = "plain"
+    style: str = "authoryear"
     entries: list[BibEntry] = field(default_factory=list)
+
+    def find_entry(self, key: str) -> BibEntry | None:
+        for entry in self.entries:
+            if entry.key == key:
+                return entry
+        return None
 
 
 # --- Content blocks ---
@@ -255,6 +261,9 @@ class Document:
         for block in self._walk_blocks(self.content):
             if isinstance(block, Paragraph) and "](http" in block.text:
                 pkgs.add("hyperref")
+
+        if self.bibliography and self.bibliography.entries:
+            pkgs.add("biblatex")
 
         return pkgs
 

--- a/texflow/serializer.py
+++ b/texflow/serializer.py
@@ -83,6 +83,9 @@ def escape_latex(text: str) -> str:
     # Links: [text](url)
     for m in re.finditer(r"\[([^\]]+)\]\(([^)]+)\)", text):
         protected.append((m.start(), m.end(), m.group()))
+    # Citations: [@key] or [@key, note]
+    for m in re.finditer(r"\[@[^\]]+\]", text):
+        protected.append((m.start(), m.end(), m.group()))
 
     if not protected:
         return _LATEX_SPECIAL.sub(lambda m: _LATEX_ESCAPE_MAP[m.group()], text)
@@ -123,6 +126,9 @@ def _convert_inline_markup(text: str) -> str:
     text = re.sub(r"(?<!\*)\*(?!\*)([^*]+)\*(?!\*)", r"\\textit{\1}", text)
     # Inline code
     text = re.sub(r"`([^`]+)`", r"\\texttt{\1}", text)
+    # Citations: [@key, note] → \cite[note]{key}, [@key] → \cite{key}
+    text = re.sub(r"\[@([\w:./-]+),\s*(.+?)\]", r"\\cite[\2]{\1}", text)
+    text = re.sub(r"\[@([\w:./-]+)\]", r"\\cite{\1}", text)
     return text
 
 
@@ -158,6 +164,11 @@ def _preamble(doc: Document) -> str:
         style_pkgs, style_preamble = resolve_style_stack(layout.styles)
         packages.update(style_pkgs)
 
+    # Biblatex is emitted separately with style option
+    has_bib = "biblatex" in packages
+    if has_bib:
+        packages.discard("biblatex")
+
     # Sort for deterministic output
     for pkg in sorted(packages):
         options = _package_options(pkg, doc)
@@ -165,6 +176,12 @@ def _preamble(doc: Document) -> str:
             lines.append(f"\\usepackage[{options}]{{{pkg}}}")
         else:
             lines.append(f"\\usepackage{{{pkg}}}")
+
+    # Biblatex after other packages
+    if has_bib and doc.bibliography:
+        bib_style = doc.bibliography.style or "authoryear"
+        lines.append(f"\\usepackage[style={bib_style},backend=biber]{{biblatex}}")
+        lines.append("\\addbibresource{references.bib}")
 
     lines.append("")
 
@@ -305,8 +322,7 @@ def _end_document(doc: Document) -> str:
     lines: list[str] = []
 
     if doc.bibliography and doc.bibliography.entries:
-        lines.append(f"\\bibliographystyle{{{doc.bibliography.style}}}")
-        lines.append("\\bibliography{references}")
+        lines.append("\\printbibliography")
         lines.append("")
 
     lines.append("\\end{document}")
@@ -488,3 +504,16 @@ def serialize(doc: Document) -> str:
         _end_document(doc),
     ]
     return "\n".join(parts)
+
+
+def serialize_bib(doc: Document) -> str:
+    """Serialize bibliography entries to BibTeX .bib format."""
+    if not doc.bibliography or not doc.bibliography.entries:
+        return ""
+    parts = []
+    for entry in doc.bibliography.entries:
+        field_lines = ",\n".join(
+            f"  {k} = {{{v}}}" for k, v in entry.fields.items()
+        )
+        parts.append(f"@{entry.entry_type}{{{entry.key},\n{field_lines}\n}}")
+    return "\n\n".join(parts) + "\n"

--- a/texflow/tex_ingestion.py
+++ b/texflow/tex_ingestion.py
@@ -608,7 +608,24 @@ _RE_BIB_ENTRY = re.compile(
     r"@(\w+)\s*\{\s*([\w:./-]+)\s*,\s*(.*?)\s*\}(?=\s*@|\s*\Z)",
     re.DOTALL,
 )
-_RE_BIB_FIELD = re.compile(r"(\w+)\s*=\s*\{([^}]*)\}")
+# Handles one level of nested braces: title = {The {RNA} Polymerase}
+_RE_BIB_FIELD = re.compile(r"(\w+)\s*=\s*\{((?:[^{}]|\{[^{}]*\})*)\}")
+
+
+def parse_bib_entry(text: str):
+    """Parse a single BibTeX entry string into a BibEntry, or None."""
+    from .model import BibEntry
+
+    m = _RE_BIB_ENTRY.search(text)
+    if not m:
+        return None
+    entry_type = m.group(1).lower()
+    key = m.group(2)
+    body = m.group(3)
+    fields: dict[str, str] = {}
+    for fm in _RE_BIB_FIELD.finditer(body):
+        fields[fm.group(1).lower()] = fm.group(2)
+    return BibEntry(key=key, entry_type=entry_type, fields=fields)
 
 
 def parse_bib_file(text: str) -> list:

--- a/texflow/tex_ingestion.py
+++ b/texflow/tex_ingestion.py
@@ -47,6 +47,14 @@ _RE_HREF = re.compile(r"\\href\{([^}]+)\}\{([^}]+)\}")
 _RE_TEXTBF = re.compile(r"\\textbf\{([^}]+)\}")
 _RE_TEXTIT = re.compile(r"\\textit\{([^}]+)\}")
 _RE_TEXTTT = re.compile(r"\\texttt\{([^}]+)\}")
+_RE_CITE = re.compile(r"\\cite\{([^}]+)\}")
+_RE_CITE_OPT = re.compile(r"\\cite\[([^\]]*)\]\{([^}]+)\}")
+_RE_TEXTCITE = re.compile(r"\\textcite\{([^}]+)\}")
+_RE_PARENCITE = re.compile(r"\\parencite\{([^}]+)\}")
+
+# Preamble: biblatex detection
+_RE_BIBLATEX = re.compile(r"\\usepackage\[([^\]]*)\]\{biblatex\}")
+_RE_ADDBIBRESOURCE = re.compile(r"\\addbibresource\{([^}]+)\}")
 
 _SECTION_LEVELS = {"section": 1, "subsection": 2, "subsubsection": 3}
 
@@ -61,6 +69,7 @@ _LAYOUT_LINES = {
     "\\tableofcontents": "toc",
     "\\listoffigures": "lof",
     "\\listoftables": "lot",
+    "\\printbibliography": "_has_bibliography",
 }
 
 _UNESCAPE_MAP = [
@@ -98,6 +107,11 @@ def _latex_inline_to_markdown(text: str) -> str:
     text = _RE_TEXTBF.sub(r"**\1**", text)
     text = _RE_TEXTIT.sub(r"*\1*", text)
     text = _RE_TEXTTT.sub(r"`\1`", text)
+    # Citations: \cite[note]{key} → [@key, note], \cite{key} → [@key]
+    text = _RE_CITE_OPT.sub(r"[@\2, \1]", text)
+    text = _RE_TEXTCITE.sub(r"[@\1]", text)
+    text = _RE_PARENCITE.sub(r"[@\1]", text)
+    text = _RE_CITE.sub(r"[@\1]", text)
     return text
 
 
@@ -125,10 +139,14 @@ def _parse_margins(opts: str) -> Margins:
     return margins
 
 
-def _parse_preamble(text: str) -> tuple[Metadata, Layout]:
-    """Extract metadata and layout from LaTeX preamble."""
+def _parse_preamble(text: str) -> tuple[Metadata, Layout, str]:
+    """Extract metadata, layout, and bibliography style from LaTeX preamble.
+
+    Returns (metadata, layout, bib_style). bib_style is empty if no biblatex found.
+    """
     meta = Metadata()
     layout = Layout()
+    bib_style = ""
 
     for line in text.splitlines():
         line = line.strip()
@@ -184,7 +202,16 @@ def _parse_preamble(text: str) -> tuple[Metadata, Layout]:
                 except ValueError:
                     pass
 
-    return meta, layout
+        # Biblatex
+        m = _RE_BIBLATEX.match(line)
+        if m:
+            opts = m.group(1)
+            for part in opts.split(","):
+                part = part.strip()
+                if part.startswith("style="):
+                    bib_style = part[6:]
+
+    return meta, layout, bib_style
 
 
 # --- Environment parsers ---
@@ -552,7 +579,7 @@ def ingest_tex(source: str) -> Document:
         body_text = body_text[:end_idx]
 
     # Parse phases
-    metadata, layout = _parse_preamble(preamble_text)
+    metadata, layout, bib_style = _parse_preamble(preamble_text)
     content, layout_flags = _parse_body(body_text)
 
     # Apply layout flags
@@ -565,4 +592,36 @@ def ingest_tex(source: str) -> Document:
     if "_abstract" in layout_flags:
         metadata.abstract = _unescape_latex(str(layout_flags["_abstract"]))
 
-    return Document(metadata=metadata, layout=layout, content=content)
+    doc = Document(metadata=metadata, layout=layout, content=content)
+
+    # Bibliography style from preamble
+    if bib_style:
+        from .model import Bibliography
+        doc.bibliography = Bibliography(style=bib_style)
+
+    return doc
+
+
+# --- BibTeX file parsing ---
+
+_RE_BIB_ENTRY = re.compile(
+    r"@(\w+)\s*\{\s*([\w:./-]+)\s*,\s*(.*?)\s*\}(?=\s*@|\s*\Z)",
+    re.DOTALL,
+)
+_RE_BIB_FIELD = re.compile(r"(\w+)\s*=\s*\{([^}]*)\}")
+
+
+def parse_bib_file(text: str) -> list:
+    """Parse a .bib file into a list of BibEntry objects."""
+    from .model import BibEntry
+
+    entries: list[BibEntry] = []
+    for m in _RE_BIB_ENTRY.finditer(text):
+        entry_type = m.group(1).lower()
+        key = m.group(2)
+        body = m.group(3)
+        fields: dict[str, str] = {}
+        for fm in _RE_BIB_FIELD.finditer(body):
+            fields[fm.group(1).lower()] = fm.group(2)
+        entries.append(BibEntry(key=key, entry_type=entry_type, fields=fields))
+    return entries

--- a/texflow/tools/document.py
+++ b/texflow/tools/document.py
@@ -305,14 +305,6 @@ def _read(section_path: str | None) -> str:
 
 # --- Bibliography actions ---
 
-import re
-
-_RE_BIB_ENTRY = re.compile(
-    r"@(\w+)\s*\{\s*([\w:./-]+)\s*,\s*(.*?)\s*\}$",
-    re.DOTALL | re.MULTILINE,
-)
-_RE_BIB_FIELD = re.compile(r"(\w+)\s*=\s*\{([^}]*)\}")
-
 _VALID_BIB_STYLES = {
     "authoryear", "numeric", "alphabetic", "authortitle",
     "verbose", "reading", "draft", "apa", "ieee", "nature",
@@ -320,25 +312,12 @@ _VALID_BIB_STYLES = {
 }
 
 
-def _parse_bibtex_entry(text: str) -> BibEntry | None:
-    """Parse a single BibTeX entry string into a BibEntry."""
-    m = _RE_BIB_ENTRY.search(text)
-    if not m:
-        return None
-    entry_type = m.group(1).lower()
-    key = m.group(2)
-    body = m.group(3)
-    fields: dict[str, str] = {}
-    for fm in _RE_BIB_FIELD.finditer(body):
-        fields[fm.group(1).lower()] = fm.group(2)
-    return BibEntry(key=key, entry_type=entry_type, fields=fields)
-
-
 def _bib_add(source: str | None) -> str:
     if not source:
         return "Error: 'source' is required. Provide a BibTeX entry, e.g.:\n@article{key, author={...}, title={...}, year={2024}}"
     doc = require_doc()
-    entry = _parse_bibtex_entry(source)
+    from ..tex_ingestion import parse_bib_entry
+    entry = parse_bib_entry(source)
     if not entry:
         return "Error: Could not parse BibTeX entry. Expected format:\n@type{key, field = {value}, ...}"
     if doc.bibliography is None:

--- a/texflow/tools/document.py
+++ b/texflow/tools/document.py
@@ -15,6 +15,8 @@ from ..formatters import (
 )
 from ..ingestion import ingest_markdown, ingest_raw, parse_markdown_blocks
 from ..model import (
+    BibEntry,
+    Bibliography,
     Document,
     DocumentClass,
     Layout,
@@ -57,6 +59,10 @@ def document_tool(
     - read: Read content of a specific section as prose text.
     - update: Update document metadata (title, author, date, abstract).
     - reset: Clear the current document and saved state. Next create/ingest starts fresh.
+    - bib_add: Add a bibliography entry (provide BibTeX-format entry as source).
+    - bib_remove: Remove a bibliography entry by key (provide key as source).
+    - bib_list: List all bibliography entries.
+    - bib_style: Set bibliography style (provide style name as source, e.g. "authoryear", "numeric").
     """
     match action:
         case "create":
@@ -71,8 +77,16 @@ def document_tool(
             return _update(title, author, date, abstract)
         case "reset":
             return _reset()
+        case "bib_add":
+            return _bib_add(source)
+        case "bib_remove":
+            return _bib_remove(source)
+        case "bib_list":
+            return _bib_list()
+        case "bib_style":
+            return _bib_style(source)
         case _:
-            return f"Unknown action: {action}. Valid actions: create, ingest, outline, read, update, reset"
+            return f"Unknown action: {action}. Valid actions: create, ingest, outline, read, update, reset, bib_add, bib_remove, bib_list, bib_style"
 
 
 def _create(
@@ -193,8 +207,16 @@ def _ingest(source: str | None, section: str | None = None) -> str:
         if source_path.exists() and source_path.is_file():
             text = source_path.read_text(encoding="utf-8")
             if source_path.suffix.lower() == ".tex":
-                from ..tex_ingestion import ingest_tex
+                from ..tex_ingestion import ingest_tex, parse_bib_file
                 doc = ingest_tex(text)
+                # Load sibling .bib file if present
+                bib_path = source_path.parent / "references.bib"
+                if bib_path.exists():
+                    entries = parse_bib_file(bib_path.read_text(encoding="utf-8"))
+                    if entries:
+                        if doc.bibliography is None:
+                            doc.bibliography = Bibliography()
+                        doc.bibliography.entries = entries
             else:
                 doc = ingest_markdown(text)
             if existing_layout is not None and not source_path.suffix.lower() == ".tex":
@@ -279,5 +301,103 @@ def _read(section_path: str | None) -> str:
         return f"Section not found: {section_path}\nAvailable sections: {', '.join(available)}"
 
     return format_blocks_as_prose(sec.content)
+
+
+# --- Bibliography actions ---
+
+import re
+
+_RE_BIB_ENTRY = re.compile(
+    r"@(\w+)\s*\{\s*([\w:./-]+)\s*,\s*(.*?)\s*\}$",
+    re.DOTALL | re.MULTILINE,
+)
+_RE_BIB_FIELD = re.compile(r"(\w+)\s*=\s*\{([^}]*)\}")
+
+_VALID_BIB_STYLES = {
+    "authoryear", "numeric", "alphabetic", "authortitle",
+    "verbose", "reading", "draft", "apa", "ieee", "nature",
+    "science", "chicago-authordate", "mla",
+}
+
+
+def _parse_bibtex_entry(text: str) -> BibEntry | None:
+    """Parse a single BibTeX entry string into a BibEntry."""
+    m = _RE_BIB_ENTRY.search(text)
+    if not m:
+        return None
+    entry_type = m.group(1).lower()
+    key = m.group(2)
+    body = m.group(3)
+    fields: dict[str, str] = {}
+    for fm in _RE_BIB_FIELD.finditer(body):
+        fields[fm.group(1).lower()] = fm.group(2)
+    return BibEntry(key=key, entry_type=entry_type, fields=fields)
+
+
+def _bib_add(source: str | None) -> str:
+    if not source:
+        return "Error: 'source' is required. Provide a BibTeX entry, e.g.:\n@article{key, author={...}, title={...}, year={2024}}"
+    doc = require_doc()
+    entry = _parse_bibtex_entry(source)
+    if not entry:
+        return "Error: Could not parse BibTeX entry. Expected format:\n@type{key, field = {value}, ...}"
+    if doc.bibliography is None:
+        doc.bibliography = Bibliography()
+    existing = doc.bibliography.find_entry(entry.key)
+    if existing:
+        return f"Error: Entry with key '{entry.key}' already exists. Remove it first or use a different key."
+    doc.bibliography.entries.append(entry)
+    auto_save()
+    fields_summary = ", ".join(f"{k}={v[:30]}..." if len(v) > 30 else f"{k}={v}" for k, v in entry.fields.items())
+    return f"Added @{entry.entry_type}{{{entry.key}}} ({fields_summary}). {len(doc.bibliography.entries)} total entries."
+
+
+def _bib_remove(source: str | None) -> str:
+    if not source:
+        return "Error: 'source' is required. Provide the citation key to remove."
+    doc = require_doc()
+    if not doc.bibliography or not doc.bibliography.entries:
+        return "No bibliography entries to remove."
+    key = source.strip()
+    before = len(doc.bibliography.entries)
+    doc.bibliography.entries = [e for e in doc.bibliography.entries if e.key != key]
+    if len(doc.bibliography.entries) == before:
+        return f"Error: No entry with key '{key}' found."
+    auto_save()
+    return f"Removed entry '{key}'. {len(doc.bibliography.entries)} entries remaining."
+
+
+def _bib_list() -> str:
+    doc = require_doc()
+    if not doc.bibliography or not doc.bibliography.entries:
+        return "No bibliography entries. Use document(action='bib_add', source='@article{key, ...}') to add entries."
+    lines = [f"Bibliography ({len(doc.bibliography.entries)} entries, style: {doc.bibliography.style}):", ""]
+    for entry in doc.bibliography.entries:
+        title = entry.fields.get("title", "")
+        author = entry.fields.get("author", "")
+        year = entry.fields.get("year", "")
+        summary = f"  @{entry.entry_type}{{{entry.key}}}"
+        if author:
+            summary += f" — {author}"
+        if title:
+            summary += f", \"{title}\""
+        if year:
+            summary += f" ({year})"
+        lines.append(summary)
+    return "\n".join(lines)
+
+
+def _bib_style(source: str | None) -> str:
+    if not source:
+        return f"Error: 'source' is required. Valid styles: {', '.join(sorted(_VALID_BIB_STYLES))}"
+    doc = require_doc()
+    style = source.strip().lower()
+    if style not in _VALID_BIB_STYLES:
+        return f"Unknown style '{style}'. Valid styles: {', '.join(sorted(_VALID_BIB_STYLES))}"
+    if doc.bibliography is None:
+        doc.bibliography = Bibliography()
+    doc.bibliography.style = style
+    auto_save()
+    return f"Bibliography style set to '{style}'."
 
 

--- a/texflow/tools/render.py
+++ b/texflow/tools/render.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from ..compiler import compile_tex, preview_page
 from ..formatters import format_compile_result, format_preview_result
-from ..serializer import serialize
+from ..serializer import serialize, serialize_bib
 from .state import auto_save, get_output_dir, require_doc
 
 
@@ -42,12 +42,13 @@ def _compile(output_path: str | None) -> str:
     global _last_result
     doc = require_doc()
     tex = serialize(doc)
+    bib = serialize_bib(doc) or None
 
     # Pre-compile capability check
     warnings = _check_packages(doc)
 
     out_dir = Path(output_path) if output_path else get_output_dir()
-    result = compile_tex(tex, output_dir=out_dir)
+    result = compile_tex(tex, output_dir=out_dir, bib_content=bib)
     _last_result = result
 
     auto_save()


### PR DESCRIPTION
## Summary

- **Citation inline markup**: `[@key]` in paragraph text, serialized to `\cite{key}` — same pattern as `**bold**`/`*italic*`
- **Bibliography management**: `bib_add`, `bib_remove`, `bib_list`, `bib_style` actions on the document tool
- **Compiler biber pass**: xelatex → biber → xelatex → xelatex when bibliography entries present
- **Round-trip support**: `.tex` ingestion reverses `\cite{}` → `[@key]`, parses sibling `.bib` files

## Changes

- `texflow/model.py` — Bibliography style default to `authoryear`, `find_entry()` helper, biblatex in `required_packages`
- `texflow/serializer.py` — Citation conversion, protected spans, biblatex preamble, `serialize_bib()`, `\printbibliography`
- `texflow/compiler.py` — `bib_content` param, `_run_engine()` extraction, conditional biber pass
- `texflow/tools/document.py` — `bib_add`/`bib_remove`/`bib_list`/`bib_style` actions, bibtex entry parser
- `texflow/tools/render.py` — Wire `serialize_bib` into compile
- `texflow/tex_ingestion.py` — Citation reversal, biblatex preamble detection, `parse_bib_file()`
- `server.py` — Updated document tool docstring

## Test plan

- [x] 465 tests pass (`uv run pytest tests/ -v`)
- [x] Live MCP: bib_add → paragraph with `[@key]` → compile → PDF has bibliography section
- [x] Round-trip: compile → reset → ingest .tex + .bib → citations and entries preserved
- [x] Biber pipeline: 4-pass compilation produces correct authoryear citations